### PR TITLE
Guled/release date field number keyboard

### DIFF
--- a/lucien-ios.xcodeproj/project.pbxproj
+++ b/lucien-ios.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		1C07CBF51F7AE1FD007C66D0 /* AddComicViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1C07CBF31F7AE1FD007C66D0 /* AddComicViewController.xib */; };
 		1C182A2F1F82CA70001566E1 /* Comic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C182A2E1F82CA70001566E1 /* Comic.swift */; };
 		1C182A321F82D1C1001566E1 /* RawRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C182A311F82D1C1001566E1 /* RawRepresentable.swift */; };
+		1CAE48D81F8412960087E96E /* LucienConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CAE48D71F8412960087E96E /* LucienConstants.swift */; };
 		1CAFFC671F797FA200B79F11 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CAFFC661F797FA200B79F11 /* AppDelegate.swift */; };
 		1CAFFC6E1F797FA200B79F11 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1CAFFC6D1F797FA200B79F11 /* Assets.xcassets */; };
 		1CAFFC711F797FA200B79F11 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1CAFFC6F1F797FA200B79F11 /* LaunchScreen.storyboard */; };
@@ -68,6 +69,7 @@
 		1C07CBF31F7AE1FD007C66D0 /* AddComicViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = AddComicViewController.xib; sourceTree = "<group>"; };
 		1C182A2E1F82CA70001566E1 /* Comic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Comic.swift; sourceTree = "<group>"; };
 		1C182A311F82D1C1001566E1 /* RawRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawRepresentable.swift; sourceTree = "<group>"; };
+		1CAE48D71F8412960087E96E /* LucienConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LucienConstants.swift; sourceTree = "<group>"; };
 		1CAFFC631F797FA200B79F11 /* lucien-ios.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "lucien-ios.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		1CAFFC661F797FA200B79F11 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1CAFFC6D1F797FA200B79F11 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 				1CAFFC6F1F797FA200B79F11 /* LaunchScreen.storyboard */,
 				1CDB6A251F79A52D003A2BB1 /* AddNewComicBook */,
 				1CDBD86E1F7C26B800408826 /* LucienTheme.swift */,
+				1CAE48D71F8412960087E96E /* LucienConstants.swift */,
 			);
 			path = "lucien-ios";
 			sourceTree = "<group>";
@@ -645,6 +648,7 @@
 				1CDBD86F1F7C26B800408826 /* LucienTheme.swift in Sources */,
 				FBD844431F798B1D00A8E352 /* RootViewController.swift in Sources */,
 				FBE07CC91F7C2A4500CF1A3F /* ProfileViewController.swift in Sources */,
+				1CAE48D81F8412960087E96E /* LucienConstants.swift in Sources */,
 				1CAFFC671F797FA200B79F11 /* AppDelegate.swift in Sources */,
 				1C07CBF41F7AE1FD007C66D0 /* AddComicViewController.swift in Sources */,
 				1C182A321F82D1C1001566E1 /* RawRepresentable.swift in Sources */,

--- a/lucien-ios/AddNewComicBook/AddComicViewController.swift
+++ b/lucien-ios/AddNewComicBook/AddComicViewController.swift
@@ -116,6 +116,18 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
         // Release Date
         configureTextFieldBorder(textField: releaseDateTextField)
         releaseDateTextField.attributedPlaceholder = createPlaceHolderAttributedString(placeholder: "Year of Release")
+        releaseDateTextField.addTarget(self, action: #selector(AddComicViewController.releaseDateEditingChanged), for: .editingChanged)
+
+        let releaseDateToolBar = UIToolbar(frame: CGRect(x: 0, y: 0, width: view.frame.width, height: 50))
+        releaseDateToolBar.barStyle = UIBarStyle.default
+        let flexSpace = UIBarButtonItem(barButtonSystemItem: UIBarButtonSystemItem.flexibleSpace, target: nil, action: nil)
+        let doneButton = UIBarButtonItem(title: "Done", style: UIBarButtonItemStyle.done, target: self, action: #selector(AddComicViewController.doneButtonTapped))
+        var barButtonItems = [UIBarButtonItem]()
+        barButtonItems.append(flexSpace)
+        barButtonItems.append(doneButton)
+        releaseDateToolBar.items = barButtonItems
+        releaseDateToolBar.sizeToFit()
+        releaseDateTextField.inputAccessoryView = releaseDateToolBar
 
         // Genre
         configurePickerUIButton(button: selectAGenreButton)
@@ -155,6 +167,20 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
         }
         finishButton.isEnabled = true
         finishButton.tintColor = LucienTheme.dark
+    }
+
+    @objc private func releaseDateEditingChanged(_ textField: UITextField) {
+        guard let text = textField.text else {
+            return
+        }
+        if text.characters.count > 4 {
+            textField.deleteBackward()
+        }
+    }
+
+    @objc func doneButtonTapped() {
+        view.endEditing(true)
+        deregisterFromKeyboardNotifications()
     }
 
     // MARK: - IBOutlet Methods
@@ -208,7 +234,6 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
                let bottomBorderSubLayer = textField.layer.sublayers,
                let comicTitleTextFieldSubLayers = comicTitleTextField.layer.sublayers else {
             return
-
         }
 
         let bottomBorder = bottomBorderSubLayer[0] as CALayer
@@ -241,30 +266,14 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
         return false
     }
 
-    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
-        if textField == releaseDateTextField {
-            let maxLength = 3
-            let currentString = textField.text
-            if let updatedString = currentString as NSString? {
-                return updatedString.length <= maxLength
-            } else {
-                return false
-            }
-        } else {
-            return false
-        }
-    }
-
     // MARK: - Keyboard Methods
 
     func registerForKeyboardNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(AddComicViewController.keyboardWasShown), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(AddComicViewController.keyboardWillBeHidden), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
     }
 
     func deregisterFromKeyboardNotifications() {
         NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIKeyboardWillShow, object: nil)
-        NotificationCenter.default.removeObserver(self, name: NSNotification.Name.UIKeyboardWillHide, object: nil)
     }
 
     @objc func keyboardWasShown(notification: NSNotification) {
@@ -283,17 +292,5 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
                 scrollView.scrollRectToVisible(activeField.frame, animated: true)
             }
         }
-    }
-
-    @objc func keyboardWillBeHidden(notification: NSNotification) {
-        guard let info = notification.userInfo,
-              let keyboardSize = (info[UIKeyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue.size else {
-                return
-        }
-        let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: -keyboardSize.height, right: 0.0)
-        scrollView.contentInset = contentInsets
-        scrollView.scrollIndicatorInsets = contentInsets
-        view.endEditing(true)
-        scrollView.isScrollEnabled = false
     }
 }

--- a/lucien-ios/AddNewComicBook/AddComicViewController.swift
+++ b/lucien-ios/AddNewComicBook/AddComicViewController.swift
@@ -241,6 +241,20 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
         return false
     }
 
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        if textField == releaseDateTextField {
+            let maxLength = 3
+            let currentString = textField.text
+            if let updatedString = currentString as NSString? {
+                return updatedString.length <= maxLength
+            } else {
+                return false
+            }
+        } else {
+            return false
+        }
+    }
+
     // MARK: - Keyboard Methods
 
     func registerForKeyboardNotifications() {

--- a/lucien-ios/AddNewComicBook/AddComicViewController.swift
+++ b/lucien-ios/AddNewComicBook/AddComicViewController.swift
@@ -55,6 +55,7 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
 
     @objc private func backButtonTapped() {
         dismiss(animated: true, completion: nil)
+        deregisterFromKeyboardNotifications()
     }
 
     private func configureNavigationController() {
@@ -114,7 +115,7 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
 
         // Release Date
         configureTextFieldBorder(textField: releaseDateTextField)
-        releaseDateTextField.attributedPlaceholder = createPlaceHolderAttributedString(placeholder: "1943")
+        releaseDateTextField.attributedPlaceholder = createPlaceHolderAttributedString(placeholder: "Year of Release")
 
         // Genre
         configurePickerUIButton(button: selectAGenreButton)
@@ -231,7 +232,17 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
         bottomBorder.backgroundColor = LucienTheme.silver.cgColor
     }
 
+    func textFieldShouldReturn(_ textField: UITextField) -> Bool {
+        if let nextTextField = textField.superview?.superview?.viewWithTag(textField.tag + 1) as? UITextField {
+            nextTextField.becomeFirstResponder()
+        } else {
+            textField.resignFirstResponder()
+        }
+        return false
+    }
+
     // MARK: - Keyboard Methods
+
     func registerForKeyboardNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(AddComicViewController.keyboardWasShown), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(AddComicViewController.keyboardWillBeHidden), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
@@ -248,7 +259,7 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
                 return
         }
         scrollView.isScrollEnabled = true
-        let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: keyboardSize.height, right: 0.0)
+        let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: keyboardSize.height + LucienConstants.keyBoardHieghtPadding, right: 0.0)
         scrollView.contentInset = contentInsets
         scrollView.scrollIndicatorInsets = contentInsets
         var aRect = view.frame

--- a/lucien-ios/AddNewComicBook/AddComicViewController.swift
+++ b/lucien-ios/AddNewComicBook/AddComicViewController.swift
@@ -31,7 +31,6 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
     @IBOutlet private weak var selectADateButton: UIButton!
     @IBOutlet private weak var selectAGenreButton: UIButton!
     @IBOutlet private weak var selectAConditionButton: UIButton!
-    @IBOutlet private weak var datePicker: UIDatePicker!
     @IBOutlet private weak var conditionPicker: UIPickerView!
     @IBOutlet private weak var genrePicker: UIPickerView!
     @IBOutlet private weak var scrollView: UIScrollView!

--- a/lucien-ios/AddNewComicBook/AddComicViewController.swift
+++ b/lucien-ios/AddNewComicBook/AddComicViewController.swift
@@ -170,9 +170,7 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
     }
 
     @objc private func releaseDateEditingChanged(_ textField: UITextField) {
-        guard let text = textField.text else {
-            return
-        }
+        guard let text = textField.text else { return }
         if text.characters.count > 4 {
             textField.deleteBackward()
         }
@@ -184,6 +182,7 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
     }
 
     // MARK: - IBOutlet Methods
+
     @IBAction func selectGenreButtonTapped(_ sender: UIButton) {
         UIView.animate(
             withDuration: 0.3,
@@ -277,18 +276,18 @@ final class AddComicViewController: UIViewController, UIPickerViewDelegate, UIPi
     }
 
     @objc func keyboardWasShown(notification: NSNotification) {
-        guard let info = notification.userInfo,
-              let keyboardSize = (info[UIKeyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue.size else {
-                return
-        }
+        guard
+            let info = notification.userInfo,
+            let keyboardSize = (info[UIKeyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue.size
+            else { return }
         scrollView.isScrollEnabled = true
-        let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: keyboardSize.height + LucienConstants.keyBoardHieghtPadding, right: 0.0)
+        let contentInsets = UIEdgeInsets(top: 0.0, left: 0.0, bottom: keyboardSize.height + LucienConstants.keyboardHeightPadding, right: 0.0)
         scrollView.contentInset = contentInsets
         scrollView.scrollIndicatorInsets = contentInsets
-        var aRect = view.frame
-        aRect.size.height -= keyboardSize.height
+        var viewFrame = view.frame
+        viewFrame.size.height -= keyboardSize.height
         if let activeField = activeField {
-            if  !aRect.contains(activeField.frame.origin) {
+            if  !viewFrame.contains(activeField.frame.origin) {
                 scrollView.scrollRectToVisible(activeField.frame, animated: true)
             }
         }

--- a/lucien-ios/AddNewComicBook/AddComicViewController.xib
+++ b/lucien-ios/AddNewComicBook/AddComicViewController.xib
@@ -56,13 +56,13 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="1677"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="COVER PHOTO" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZeW-7M-5vu">
-                            <rect key="frame" x="24" y="27" width="115" height="15.5"/>
+                            <rect key="frame" x="24" y="27" width="115" height="14"/>
                             <fontDescription key="fontDescription" name="Muli-Light" family="Muli" pointSize="12"/>
                             <color key="textColor" red="0.5607843137254902" green="0.56470588235294117" blue="0.60392156862745094" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IDD-iP-gW7">
-                            <rect key="frame" x="15" y="44.5" width="143" height="210"/>
+                            <rect key="frame" x="15" y="43" width="143" height="210"/>
                             <inset key="titleEdgeInsets" minX="0.0" minY="25" maxX="0.0" maxY="0.0"/>
                             <state key="normal" backgroundImage="bookCoverButton">
                                 <attributedString key="attributedTitle">
@@ -80,7 +80,7 @@ Photo</string>
                             </state>
                         </button>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="Pct-Cd-9cv">
-                            <rect key="frame" x="24" y="260.5" width="320" height="746"/>
+                            <rect key="frame" x="24" y="259" width="320" height="741"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="8ee-NH-Jbh">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="63"/>
@@ -107,7 +107,7 @@ Photo</string>
                                             </connections>
                                         </textField>
                                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This field is required." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6vw-lW-ZtI">
-                                            <rect key="frame" x="0.0" y="63" width="113.5" height="0.0"/>
+                                            <rect key="frame" x="0.0" y="63" width="111" height="0.0"/>
                                             <fontDescription key="fontDescription" name="Muli-Regular" family="Muli" pointSize="12"/>
                                             <color key="textColor" red="1" green="0.23137254901960785" blue="0.32549019607843138" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
@@ -150,16 +150,16 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="fVe-8d-Tvi">
-                                    <rect key="frame" x="0.0" y="190" width="320" height="57.5"/>
+                                    <rect key="frame" x="0.0" y="190" width="320" height="56"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="STORY TITLE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9jV-Sr-z48">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="15.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="14"/>
                                             <fontDescription key="fontDescription" name="Muli-Light" family="Muli" pointSize="12"/>
                                             <color key="textColor" red="0.5607843137254902" green="0.56470588235294117" blue="0.60392156862745094" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <textField opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MqB-MZ-awC">
-                                            <rect key="frame" x="0.0" y="27.5" width="320" height="30"/>
+                                            <rect key="frame" x="0.0" y="26" width="320" height="30"/>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <textInputTraits key="textInputTraits" autocorrectionType="no"/>
@@ -176,16 +176,16 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="9YU-qf-scF">
-                                    <rect key="frame" x="0.0" y="279.5" width="320" height="57.5"/>
+                                    <rect key="frame" x="0.0" y="278" width="320" height="56"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ISSUE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tQp-yn-pha">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="15.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="14"/>
                                             <fontDescription key="fontDescription" name="Muli-Light" family="Muli" pointSize="12"/>
                                             <color key="textColor" red="0.5607843137254902" green="0.56470588235294117" blue="0.60392156862745094" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <textField opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Kwp-Vh-ark">
-                                            <rect key="frame" x="0.0" y="27.5" width="320" height="30"/>
+                                            <rect key="frame" x="0.0" y="26" width="320" height="30"/>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <textInputTraits key="textInputTraits" autocorrectionType="no"/>
@@ -202,7 +202,7 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="qSd-Yt-2xk">
-                                    <rect key="frame" x="0.0" y="369" width="320" height="63"/>
+                                    <rect key="frame" x="0.0" y="366" width="320" height="63"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PUBLISHER" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rah-tt-duF">
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="21"/>
@@ -231,7 +231,7 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="eS6-d2-1CF">
-                                    <rect key="frame" x="0.0" y="464" width="320" height="63"/>
+                                    <rect key="frame" x="0.0" y="461" width="320" height="63"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RELEASE DATE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oyx-gl-cmU">
                                             <rect key="frame" x="0.0" y="0.0" width="85.5" height="21"/>
@@ -259,10 +259,10 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="zg8-eF-OR5">
-                                    <rect key="frame" x="0.0" y="559" width="320" height="76"/>
+                                    <rect key="frame" x="0.0" y="556" width="320" height="76"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GENRE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uFa-hA-XU1">
-                                            <rect key="frame" x="0.0" y="0.0" width="40" height="21"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="41" height="21"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="21" id="uve-QV-AQF"/>
                                             </constraints>
@@ -306,10 +306,10 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="xvd-dF-dp6">
-                                    <rect key="frame" x="0.0" y="667" width="320" height="79"/>
+                                    <rect key="frame" x="0.0" y="664" width="320" height="77"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CONDITION" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KtO-eh-4L9">
-                                            <rect key="frame" x="0.0" y="0.0" width="66.5" height="21"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="66" height="21"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="21" id="nKe-Zk-eAr"/>
                                             </constraints>
@@ -318,7 +318,7 @@ Photo</string>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZXp-2w-6eh">
-                                            <rect key="frame" x="0.0" y="33" width="320" height="33"/>
+                                            <rect key="frame" x="0.0" y="33" width="320" height="31"/>
                                             <fontDescription key="fontDescription" name="Muli-Regular" family="Muli" pointSize="16"/>
                                             <state key="normal" title="Select a Condition">
                                                 <color key="titleColor" red="0.16862745098039217" green="0.1764705882352941" blue="0.25882352941176467" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -328,14 +328,14 @@ Photo</string>
                                             </connections>
                                         </button>
                                         <pickerView hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1zr-ip-Ltu">
-                                            <rect key="frame" x="0.0" y="72" width="320" height="0.0"/>
+                                            <rect key="frame" x="0.0" y="70" width="320" height="0.0"/>
                                             <connections>
                                                 <outlet property="dataSource" destination="-1" id="2Ri-tm-0Jh"/>
                                                 <outlet property="delegate" destination="-1" id="PLd-4D-Txi"/>
                                             </connections>
                                         </pickerView>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wKY-4h-eXB">
-                                            <rect key="frame" x="0.0" y="78" width="320" height="1"/>
+                                            <rect key="frame" x="0.0" y="76" width="320" height="1"/>
                                             <color key="backgroundColor" red="0.83529411760000005" green="0.83529411760000005" blue="0.85098039219999999" alpha="1" colorSpace="calibratedRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="1" id="Url-8V-m8f"/>

--- a/lucien-ios/AddNewComicBook/AddComicViewController.xib
+++ b/lucien-ios/AddNewComicBook/AddComicViewController.xib
@@ -28,7 +28,6 @@
                 <outlet property="conditionPicker" destination="1zr-ip-Ltu" id="wNw-n3-tiT"/>
                 <outlet property="coverPhotoButton" destination="IDD-iP-gW7" id="mbO-dc-cWI"/>
                 <outlet property="coverPhotoLabel" destination="ZeW-7M-5vu" id="Fqp-sQ-Q6j"/>
-                <outlet property="datePicker" destination="Ayn-n0-Cph" id="z4L-pM-ub9"/>
                 <outlet property="genreBottomLine" destination="UCL-mM-64f" id="xbj-mc-XlW"/>
                 <outlet property="genreLabel" destination="uFa-hA-XU1" id="rjc-Tc-A75"/>
                 <outlet property="genrePicker" destination="fCM-4s-5OC" id="EEm-pY-bqH"/>
@@ -293,12 +292,6 @@ Photo</string>
                                                 <action selector="selectADateButtonTapped:" destination="-1" eventType="touchUpInside" id="4r4-bM-0jR"/>
                                             </connections>
                                         </button>
-                                        <datePicker hidden="YES" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" datePickerMode="date" minuteInterval="1" translatesAutoresizingMaskIntoConstraints="NO" id="Ayn-n0-Cph">
-                                            <rect key="frame" x="0.0" y="72" width="320" height="0.0"/>
-                                            <date key="date" timeIntervalSinceReferenceDate="528401103.45546001">
-                                                <!--2017-09-29 18:05:03 +0000-->
-                                            </date>
-                                        </datePicker>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5JR-bX-0to">
                                             <rect key="frame" x="0.0" y="78" width="320" height="1"/>
                                             <color key="backgroundColor" red="0.83529411764705885" green="0.83529411764705885" blue="0.85098039215686272" alpha="1" colorSpace="calibratedRGB"/>

--- a/lucien-ios/AddNewComicBook/AddComicViewController.xib
+++ b/lucien-ios/AddNewComicBook/AddComicViewController.xib
@@ -35,11 +35,10 @@
                 <outlet property="issueTextField" destination="Kwp-Vh-ark" id="dON-bl-xbJ"/>
                 <outlet property="publisherLabel" destination="rah-tt-duF" id="btX-ov-Iov"/>
                 <outlet property="publisherTextField" destination="uhS-Ot-Cen" id="NDF-1P-p2k"/>
-                <outlet property="releaseDateBottomLine" destination="5JR-bX-0to" id="6sO-wF-sie"/>
                 <outlet property="releaseDateLabel" destination="oyx-gl-cmU" id="1q8-pU-9Jc"/>
+                <outlet property="releaseDateTextField" destination="XFa-J4-Z4b" id="41f-Rj-0ya"/>
                 <outlet property="scrollView" destination="8pQ-9n-KZP" id="P3h-s3-pwy"/>
                 <outlet property="selectAConditionButton" destination="ZXp-2w-6eh" id="GBp-m0-CUU"/>
-                <outlet property="selectADateButton" destination="UOn-Nc-ucF" id="nyb-RN-gNw"/>
                 <outlet property="selectAGenreButton" destination="1aa-2q-qU9" id="7Jh-hk-Bo9"/>
                 <outlet property="storyTitleLabel" destination="9jV-Sr-z48" id="xJt-v8-aUR"/>
                 <outlet property="storyTitleTextField" destination="MqB-MZ-awC" id="m7w-F6-Q9E"/>
@@ -57,13 +56,13 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="1677"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="COVER PHOTO" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZeW-7M-5vu">
-                            <rect key="frame" x="24" y="27" width="115" height="15.5"/>
+                            <rect key="frame" x="24" y="27" width="115" height="14"/>
                             <fontDescription key="fontDescription" name="Muli-Light" family="Muli" pointSize="12"/>
                             <color key="textColor" red="0.5607843137254902" green="0.56470588235294117" blue="0.60392156862745094" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IDD-iP-gW7">
-                            <rect key="frame" x="15" y="44.5" width="143" height="210"/>
+                            <rect key="frame" x="15" y="43" width="143" height="210"/>
                             <inset key="titleEdgeInsets" minX="0.0" minY="25" maxX="0.0" maxY="0.0"/>
                             <state key="normal" backgroundImage="bookCoverButton">
                                 <attributedString key="attributedTitle">
@@ -120,7 +119,7 @@ Photo</string>
                             </state>
                         </button>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="Pct-Cd-9cv">
-                            <rect key="frame" x="24" y="260.5" width="320" height="762"/>
+                            <rect key="frame" x="24" y="259" width="320" height="741"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="8ee-NH-Jbh">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="63"/>
@@ -141,13 +140,13 @@ Photo</string>
                                             </constraints>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                            <textInputTraits key="textInputTraits"/>
+                                            <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                                             <connections>
                                                 <outlet property="delegate" destination="-1" id="cuU-PQ-Azx"/>
                                             </connections>
                                         </textField>
                                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This field is required." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6vw-lW-ZtI">
-                                            <rect key="frame" x="0.0" y="63" width="113.5" height="0.0"/>
+                                            <rect key="frame" x="0.0" y="63" width="111" height="0.0"/>
                                             <fontDescription key="fontDescription" name="Muli-Regular" family="Muli" pointSize="12"/>
                                             <color key="textColor" red="1" green="0.23137254901960785" blue="0.32549019607843138" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
@@ -176,7 +175,7 @@ Photo</string>
                                             <rect key="frame" x="0.0" y="33" width="320" height="30"/>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                            <textInputTraits key="textInputTraits"/>
+                                            <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                                             <connections>
                                                 <outlet property="delegate" destination="-1" id="3rZ-Wr-Cjw"/>
                                             </connections>
@@ -190,19 +189,19 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="fVe-8d-Tvi">
-                                    <rect key="frame" x="0.0" y="190" width="320" height="57.5"/>
+                                    <rect key="frame" x="0.0" y="190" width="320" height="56"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="STORY TITLE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9jV-Sr-z48">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="15.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="14"/>
                                             <fontDescription key="fontDescription" name="Muli-Light" family="Muli" pointSize="12"/>
                                             <color key="textColor" red="0.5607843137254902" green="0.56470588235294117" blue="0.60392156862745094" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MqB-MZ-awC">
-                                            <rect key="frame" x="0.0" y="27.5" width="320" height="30"/>
+                                            <rect key="frame" x="0.0" y="26" width="320" height="30"/>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                            <textInputTraits key="textInputTraits"/>
+                                            <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                                             <connections>
                                                 <outlet property="delegate" destination="-1" id="eFm-KJ-gSN"/>
                                             </connections>
@@ -216,19 +215,19 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="9YU-qf-scF">
-                                    <rect key="frame" x="0.0" y="279.5" width="320" height="57.5"/>
+                                    <rect key="frame" x="0.0" y="278" width="320" height="56"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ISSUE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tQp-yn-pha">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="15.5"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="14"/>
                                             <fontDescription key="fontDescription" name="Muli-Light" family="Muli" pointSize="12"/>
                                             <color key="textColor" red="0.5607843137254902" green="0.56470588235294117" blue="0.60392156862745094" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Kwp-Vh-ark">
-                                            <rect key="frame" x="0.0" y="27.5" width="320" height="30"/>
+                                            <rect key="frame" x="0.0" y="26" width="320" height="30"/>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                            <textInputTraits key="textInputTraits"/>
+                                            <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                                             <connections>
                                                 <outlet property="delegate" destination="-1" id="HyP-4a-Zht"/>
                                             </connections>
@@ -242,7 +241,7 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="qSd-Yt-2xk">
-                                    <rect key="frame" x="0.0" y="369" width="320" height="63"/>
+                                    <rect key="frame" x="0.0" y="366" width="320" height="63"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PUBLISHER" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rah-tt-duF">
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="21"/>
@@ -257,7 +256,7 @@ Photo</string>
                                             <rect key="frame" x="0.0" y="33" width="320" height="30"/>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                            <textInputTraits key="textInputTraits"/>
+                                            <textInputTraits key="textInputTraits" autocorrectionType="no"/>
                                             <connections>
                                                 <outlet property="delegate" destination="-1" id="5Sb-68-hS7"/>
                                             </connections>
@@ -271,7 +270,7 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="eS6-d2-1CF">
-                                    <rect key="frame" x="0.0" y="464" width="320" height="79"/>
+                                    <rect key="frame" x="0.0" y="461" width="320" height="63"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RELEASE DATE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oyx-gl-cmU">
                                             <rect key="frame" x="0.0" y="0.0" width="85.5" height="21"/>
@@ -282,36 +281,27 @@ Photo</string>
                                             <color key="textColor" red="0.5607843137254902" green="0.56470588235294117" blue="0.60392156862745094" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="UOn-Nc-ucF">
-                                            <rect key="frame" x="0.0" y="33" width="320" height="33"/>
-                                            <fontDescription key="fontDescription" name="Muli-Regular" family="Muli" pointSize="16"/>
-                                            <state key="normal" title="Select a Date">
-                                                <color key="titleColor" red="0.16862745098039217" green="0.1764705882352941" blue="0.25882352941176467" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                            </state>
+                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XFa-J4-Z4b">
+                                            <rect key="frame" x="0.0" y="33" width="320" height="30"/>
+                                            <nil key="textColor"/>
+                                            <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                            <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
                                             <connections>
-                                                <action selector="selectADateButtonTapped:" destination="-1" eventType="touchUpInside" id="4r4-bM-0jR"/>
+                                                <outlet property="delegate" destination="-1" id="jXe-UE-f7o"/>
                                             </connections>
-                                        </button>
-                                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5JR-bX-0to">
-                                            <rect key="frame" x="0.0" y="78" width="320" height="1"/>
-                                            <color key="backgroundColor" red="0.83529411764705885" green="0.83529411764705885" blue="0.85098039215686272" alpha="1" colorSpace="calibratedRGB"/>
-                                            <constraints>
-                                                <constraint firstAttribute="height" constant="1" id="vbb-3X-rL2"/>
-                                            </constraints>
-                                        </view>
+                                        </textField>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="5JR-bX-0to" firstAttribute="leading" secondItem="eS6-d2-1CF" secondAttribute="leading" id="CY9-QZ-H1V"/>
-                                        <constraint firstAttribute="trailing" secondItem="UOn-Nc-ucF" secondAttribute="trailing" id="OXh-sG-m7I"/>
-                                        <constraint firstAttribute="trailing" secondItem="5JR-bX-0to" secondAttribute="trailing" id="aIT-h1-4Q5"/>
-                                        <constraint firstItem="UOn-Nc-ucF" firstAttribute="leading" secondItem="eS6-d2-1CF" secondAttribute="leading" id="iZH-Ep-xdq"/>
+                                        <constraint firstAttribute="trailing" secondItem="XFa-J4-Z4b" secondAttribute="trailing" id="5lQ-Wk-xzB"/>
+                                        <constraint firstAttribute="bottom" secondItem="XFa-J4-Z4b" secondAttribute="bottom" id="AB5-9F-iTn"/>
+                                        <constraint firstItem="XFa-J4-Z4b" firstAttribute="leading" secondItem="eS6-d2-1CF" secondAttribute="leading" id="e5b-Kq-7UL"/>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="zg8-eF-OR5">
-                                    <rect key="frame" x="0.0" y="575" width="320" height="76"/>
+                                    <rect key="frame" x="0.0" y="556" width="320" height="76"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GENRE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uFa-hA-XU1">
-                                            <rect key="frame" x="0.0" y="0.0" width="40" height="21"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="41" height="21"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="21" id="uve-QV-AQF"/>
                                             </constraints>
@@ -355,10 +345,10 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="xvd-dF-dp6">
-                                    <rect key="frame" x="0.0" y="683" width="320" height="79"/>
+                                    <rect key="frame" x="0.0" y="664" width="320" height="77"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CONDITION" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KtO-eh-4L9">
-                                            <rect key="frame" x="0.0" y="0.0" width="66.5" height="21"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="66" height="21"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="21" id="nKe-Zk-eAr"/>
                                             </constraints>
@@ -367,7 +357,7 @@ Photo</string>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZXp-2w-6eh">
-                                            <rect key="frame" x="0.0" y="33" width="320" height="33"/>
+                                            <rect key="frame" x="0.0" y="33" width="320" height="31"/>
                                             <fontDescription key="fontDescription" name="Muli-Regular" family="Muli" pointSize="16"/>
                                             <state key="normal" title="Select a Condition">
                                                 <color key="titleColor" red="0.16862745098039217" green="0.1764705882352941" blue="0.25882352941176467" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -377,14 +367,14 @@ Photo</string>
                                             </connections>
                                         </button>
                                         <pickerView hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1zr-ip-Ltu">
-                                            <rect key="frame" x="0.0" y="72" width="320" height="0.0"/>
+                                            <rect key="frame" x="0.0" y="70" width="320" height="0.0"/>
                                             <connections>
                                                 <outlet property="dataSource" destination="-1" id="2Ri-tm-0Jh"/>
                                                 <outlet property="delegate" destination="-1" id="PLd-4D-Txi"/>
                                             </connections>
                                         </pickerView>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wKY-4h-eXB">
-                                            <rect key="frame" x="0.0" y="78" width="320" height="1"/>
+                                            <rect key="frame" x="0.0" y="76" width="320" height="1"/>
                                             <color key="backgroundColor" red="0.83529411760000005" green="0.83529411760000005" blue="0.85098039219999999" alpha="1" colorSpace="calibratedRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="1" id="Url-8V-m8f"/>

--- a/lucien-ios/AddNewComicBook/AddComicViewController.xib
+++ b/lucien-ios/AddNewComicBook/AddComicViewController.xib
@@ -56,13 +56,13 @@
                     <rect key="frame" x="0.0" y="0.0" width="375" height="1677"/>
                     <subviews>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="COVER PHOTO" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZeW-7M-5vu">
-                            <rect key="frame" x="24" y="27" width="115" height="14"/>
+                            <rect key="frame" x="24" y="27" width="115" height="15.5"/>
                             <fontDescription key="fontDescription" name="Muli-Light" family="Muli" pointSize="12"/>
                             <color key="textColor" red="0.5607843137254902" green="0.56470588235294117" blue="0.60392156862745094" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="characterWrap" hasAttributedTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IDD-iP-gW7">
-                            <rect key="frame" x="15" y="43" width="143" height="210"/>
+                            <rect key="frame" x="15" y="44.5" width="143" height="210"/>
                             <inset key="titleEdgeInsets" minX="0.0" minY="25" maxX="0.0" maxY="0.0"/>
                             <state key="normal" backgroundImage="bookCoverButton">
                                 <attributedString key="attributedTitle">
@@ -73,53 +73,14 @@ Photo</string>
                                         <attributes>
                                             <color key="NSColor" red="0.34117999999999998" green="0.27843000000000001" blue="0.31764999999999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <font key="NSFont" size="13" name="Muli-Bold"/>
-                                            <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO">
-                                                <tabStops>
-                                                    <textTab alignment="left" location="28">
-                                                        <options/>
-                                                    </textTab>
-                                                    <textTab alignment="left" location="56">
-                                                        <options/>
-                                                    </textTab>
-                                                    <textTab alignment="left" location="84">
-                                                        <options/>
-                                                    </textTab>
-                                                    <textTab alignment="left" location="112">
-                                                        <options/>
-                                                    </textTab>
-                                                    <textTab alignment="left" location="140">
-                                                        <options/>
-                                                    </textTab>
-                                                    <textTab alignment="left" location="168">
-                                                        <options/>
-                                                    </textTab>
-                                                    <textTab alignment="left" location="196">
-                                                        <options/>
-                                                    </textTab>
-                                                    <textTab alignment="left" location="224">
-                                                        <options/>
-                                                    </textTab>
-                                                    <textTab alignment="left" location="252">
-                                                        <options/>
-                                                    </textTab>
-                                                    <textTab alignment="left" location="280">
-                                                        <options/>
-                                                    </textTab>
-                                                    <textTab alignment="left" location="308">
-                                                        <options/>
-                                                    </textTab>
-                                                    <textTab alignment="left" location="336">
-                                                        <options/>
-                                                    </textTab>
-                                                </tabStops>
-                                            </paragraphStyle>
+                                            <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0" allowsDefaultTighteningForTruncation="NO"/>
                                         </attributes>
                                     </fragment>
                                 </attributedString>
                             </state>
                         </button>
                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="32" translatesAutoresizingMaskIntoConstraints="NO" id="Pct-Cd-9cv">
-                            <rect key="frame" x="24" y="259" width="320" height="741"/>
+                            <rect key="frame" x="24" y="260.5" width="320" height="746"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="8ee-NH-Jbh">
                                     <rect key="frame" x="0.0" y="0.0" width="320" height="63"/>
@@ -146,7 +107,7 @@ Photo</string>
                                             </connections>
                                         </textField>
                                         <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="This field is required." textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="6vw-lW-ZtI">
-                                            <rect key="frame" x="0.0" y="63" width="111" height="0.0"/>
+                                            <rect key="frame" x="0.0" y="63" width="113.5" height="0.0"/>
                                             <fontDescription key="fontDescription" name="Muli-Regular" family="Muli" pointSize="12"/>
                                             <color key="textColor" red="1" green="0.23137254901960785" blue="0.32549019607843138" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
@@ -171,7 +132,7 @@ Photo</string>
                                             <color key="textColor" red="0.5607843137254902" green="0.56470588235294117" blue="0.60392156862745094" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0uv-dQ-6SL">
+                                        <textField opaque="NO" tag="1" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="0uv-dQ-6SL">
                                             <rect key="frame" x="0.0" y="33" width="320" height="30"/>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -189,16 +150,16 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="fVe-8d-Tvi">
-                                    <rect key="frame" x="0.0" y="190" width="320" height="56"/>
+                                    <rect key="frame" x="0.0" y="190" width="320" height="57.5"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="STORY TITLE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9jV-Sr-z48">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="14"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="15.5"/>
                                             <fontDescription key="fontDescription" name="Muli-Light" family="Muli" pointSize="12"/>
                                             <color key="textColor" red="0.5607843137254902" green="0.56470588235294117" blue="0.60392156862745094" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MqB-MZ-awC">
-                                            <rect key="frame" x="0.0" y="26" width="320" height="30"/>
+                                        <textField opaque="NO" tag="2" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="MqB-MZ-awC">
+                                            <rect key="frame" x="0.0" y="27.5" width="320" height="30"/>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <textInputTraits key="textInputTraits" autocorrectionType="no"/>
@@ -215,16 +176,16 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="9YU-qf-scF">
-                                    <rect key="frame" x="0.0" y="278" width="320" height="56"/>
+                                    <rect key="frame" x="0.0" y="279.5" width="320" height="57.5"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="ISSUE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tQp-yn-pha">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="14"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="15.5"/>
                                             <fontDescription key="fontDescription" name="Muli-Light" family="Muli" pointSize="12"/>
                                             <color key="textColor" red="0.5607843137254902" green="0.56470588235294117" blue="0.60392156862745094" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Kwp-Vh-ark">
-                                            <rect key="frame" x="0.0" y="26" width="320" height="30"/>
+                                        <textField opaque="NO" tag="3" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="Kwp-Vh-ark">
+                                            <rect key="frame" x="0.0" y="27.5" width="320" height="30"/>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                             <textInputTraits key="textInputTraits" autocorrectionType="no"/>
@@ -241,7 +202,7 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="qSd-Yt-2xk">
-                                    <rect key="frame" x="0.0" y="366" width="320" height="63"/>
+                                    <rect key="frame" x="0.0" y="369" width="320" height="63"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="PUBLISHER" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rah-tt-duF">
                                             <rect key="frame" x="0.0" y="0.0" width="320" height="21"/>
@@ -252,7 +213,7 @@ Photo</string>
                                             <color key="textColor" red="0.5607843137254902" green="0.56470588235294117" blue="0.60392156862745094" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="uhS-Ot-Cen">
+                                        <textField opaque="NO" tag="4" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="uhS-Ot-Cen">
                                             <rect key="frame" x="0.0" y="33" width="320" height="30"/>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
@@ -270,7 +231,7 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="eS6-d2-1CF">
-                                    <rect key="frame" x="0.0" y="461" width="320" height="63"/>
+                                    <rect key="frame" x="0.0" y="464" width="320" height="63"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="RELEASE DATE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oyx-gl-cmU">
                                             <rect key="frame" x="0.0" y="0.0" width="85.5" height="21"/>
@@ -281,11 +242,11 @@ Photo</string>
                                             <color key="textColor" red="0.5607843137254902" green="0.56470588235294117" blue="0.60392156862745094" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                             <nil key="highlightedColor"/>
                                         </label>
-                                        <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XFa-J4-Z4b">
+                                        <textField opaque="NO" tag="5" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" placeholder="Year of Release " textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="XFa-J4-Z4b">
                                             <rect key="frame" x="0.0" y="33" width="320" height="30"/>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                            <textInputTraits key="textInputTraits" keyboardType="decimalPad"/>
+                                            <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
                                             <connections>
                                                 <outlet property="delegate" destination="-1" id="jXe-UE-f7o"/>
                                             </connections>
@@ -298,10 +259,10 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="zg8-eF-OR5">
-                                    <rect key="frame" x="0.0" y="556" width="320" height="76"/>
+                                    <rect key="frame" x="0.0" y="559" width="320" height="76"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="GENRE" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="uFa-hA-XU1">
-                                            <rect key="frame" x="0.0" y="0.0" width="41" height="21"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="40" height="21"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="21" id="uve-QV-AQF"/>
                                             </constraints>
@@ -345,10 +306,10 @@ Photo</string>
                                     </constraints>
                                 </stackView>
                                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="12" translatesAutoresizingMaskIntoConstraints="NO" id="xvd-dF-dp6">
-                                    <rect key="frame" x="0.0" y="664" width="320" height="77"/>
+                                    <rect key="frame" x="0.0" y="667" width="320" height="79"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="CONDITION" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="KtO-eh-4L9">
-                                            <rect key="frame" x="0.0" y="0.0" width="66" height="21"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="66.5" height="21"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="21" id="nKe-Zk-eAr"/>
                                             </constraints>
@@ -357,7 +318,7 @@ Photo</string>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZXp-2w-6eh">
-                                            <rect key="frame" x="0.0" y="33" width="320" height="31"/>
+                                            <rect key="frame" x="0.0" y="33" width="320" height="33"/>
                                             <fontDescription key="fontDescription" name="Muli-Regular" family="Muli" pointSize="16"/>
                                             <state key="normal" title="Select a Condition">
                                                 <color key="titleColor" red="0.16862745098039217" green="0.1764705882352941" blue="0.25882352941176467" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -367,14 +328,14 @@ Photo</string>
                                             </connections>
                                         </button>
                                         <pickerView hidden="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="1zr-ip-Ltu">
-                                            <rect key="frame" x="0.0" y="70" width="320" height="0.0"/>
+                                            <rect key="frame" x="0.0" y="72" width="320" height="0.0"/>
                                             <connections>
                                                 <outlet property="dataSource" destination="-1" id="2Ri-tm-0Jh"/>
                                                 <outlet property="delegate" destination="-1" id="PLd-4D-Txi"/>
                                             </connections>
                                         </pickerView>
                                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="wKY-4h-eXB">
-                                            <rect key="frame" x="0.0" y="76" width="320" height="1"/>
+                                            <rect key="frame" x="0.0" y="78" width="320" height="1"/>
                                             <color key="backgroundColor" red="0.83529411760000005" green="0.83529411760000005" blue="0.85098039219999999" alpha="1" colorSpace="calibratedRGB"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="1" id="Url-8V-m8f"/>

--- a/lucien-ios/AddNewComicBook/AddComicViewController.xib
+++ b/lucien-ios/AddNewComicBook/AddComicViewController.xib
@@ -246,7 +246,7 @@ Photo</string>
                                             <rect key="frame" x="0.0" y="33" width="320" height="30"/>
                                             <nil key="textColor"/>
                                             <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                            <textInputTraits key="textInputTraits" keyboardType="numberPad"/>
+                                            <textInputTraits key="textInputTraits" keyboardType="numberPad" returnKeyType="done"/>
                                             <connections>
                                                 <outlet property="delegate" destination="-1" id="jXe-UE-f7o"/>
                                             </connections>

--- a/lucien-ios/LucienConstants.swift
+++ b/lucien-ios/LucienConstants.swift
@@ -9,6 +9,5 @@
 import Foundation
 
 final class LucienConstants {
-    static let keyBoardHieghtPadding = CGFloat(40)
+    static let keyBoardHieghtPadding = CGFloat(50)
 }
-

--- a/lucien-ios/LucienConstants.swift
+++ b/lucien-ios/LucienConstants.swift
@@ -1,0 +1,14 @@
+//
+//  LucienConstants.swift
+//  lucien-ios
+//
+//  Created by Ahmed, Guled on 10/3/17.
+//  Copyright © 2017 Intrepid Pursuits. All rights reserved.
+//
+
+import Foundation
+
+final class LucienConstants {
+    static let keyBoardHieghtPadding = CGFloat(40)
+}
+

--- a/lucien-ios/LucienConstants.swift
+++ b/lucien-ios/LucienConstants.swift
@@ -9,5 +9,5 @@
 import Foundation
 
 final class LucienConstants {
-    static let keyBoardHieghtPadding = CGFloat(50)
+    static let keyboardHeightPadding = CGFloat(50)
 }


### PR DESCRIPTION
This update includes the following.

* During our sprint demo this morning our client, project manager, designer and I came discussed changes that needed to be made for the release date field. I have redesigned the field and converted it to a textfield. 
* You can now tap the return key of the keyboard and continue entering information on other fields without having to tap on the field itself.
* The scrollview responds to the keyboard when it is presented. 
